### PR TITLE
Remove the duplicate title

### DIFF
--- a/src/Final HUDM5026 Zhixing Zhou_new.Rmd
+++ b/src/Final HUDM5026 Zhixing Zhou_new.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "What personal trait is related with wealth accumulation?"
+title: "What Personal Trait Is Related With Wealth Accumulation?"
 author: "Zhixing Zhou"
 date: '2022-12-20'
 output:
@@ -12,7 +12,6 @@ knitr::opts_chunk$set(echo = TRUE)
 knitr::opts_chunk$set(tidy.opts=list(width.cutoff=60),tidy=TRUE)
 ```
 
-# What Personal Trait Is Related With Wealth Accumulation?
 
 ## 1. Introduction & literature review
 


### PR DESCRIPTION
I recommend the removal of the second title in the code and the fixing of the capitalization in the main title because it was redundant in the output report and makes for a more streamlined report.

This will help because the html report generated by the code is now more streamlined without the title stated both at the start of the document and again before the start of the literature review.