### PR TITLE
Improve spacing and indentation of regression section

### DIFF
--- a/src/Final HUDM5026 Zhixing Zhou_new.Rmd
+++ b/src/Final HUDM5026 Zhixing Zhou_new.Rmd
@@ -194,11 +194,21 @@ ggplot(data = bbctried, mapping = aes(group =MinSavings,x=FinancialCapabilities,
 [Regression Analysis]{.underline}
 
 ```{r}
-#Conduct Regression Analysis
 
-lm1<-lm(data=bbctried,formula=MinSavings~FinancialKnowledge+log(FinancialCapabilities)+Age+Education+Income)
+# Conduct Regression Analysis
+lm1 <-lm(data = bbctried,
+         formula = MinSavings ~ 
+           FinancialKnowledge +
+           log(FinancialCapabilities) +
+           Age +
+           Education +
+           Income
+         )
+
 summary(lm1)
+
 par(mfrow=c(2,2))
+
 plot(lm1)
 
 ```


### PR DESCRIPTION
I recommend the adding more spacing and indentations to the regression analysis section to improve the readability of the code.

This will help because when someone new or someone returning after an extended period views the code, they can easily parse through the code and the different values used to build the regression model.